### PR TITLE
Fixed uppercase letters ascii representation

### DIFF
--- a/src/password-generator.js
+++ b/src/password-generator.js
@@ -21,7 +21,7 @@ class PasswordGenerator{
 
     #randomFunc = {
         hasLower: ()=> { return this.#getRandomCharacter(97,26)},
-        hasUpper: ()=> { return this.#getRandomCharacter(97,26)},
+        hasUpper: ()=> { return this.#getRandomCharacter(65,26)},
         hasNumber: ()=>{ return this.#getRandomCharacter(48,10) },
         hasSymbol: ()=> { return this.settings.allowedSymbols[Math.floor(Math.random() * this.settings.allowedSymbols.length)];
         },


### PR DESCRIPTION
According to the [ASCII table](https://www.rapidtables.com/code/text/ascii-table.html), Uppercase alphabet letters ASCII-representation starts from 65 not 97.